### PR TITLE
Split provider/requestor interfaces

### DIFF
--- a/golem_task_api/proto/golem_task_api.proto
+++ b/golem_task_api/proto/golem_task_api.proto
@@ -2,16 +2,13 @@ syntax = "proto3";
 
 package golem_task_api;
 
-service RequestorGolemApp {
+service RequestorApp {
   rpc CreateTask (CreateTaskRequest) returns (CreateTaskReply) {}
   rpc NextSubtask (NextSubtaskRequest) returns (NextSubtaskReply) {}
   rpc Verify (VerifyRequest) returns (VerifyReply) {}
   rpc RunBenchmark (RunBenchmarkRequest) returns (RunBenchmarkReply) {}
-}
 
-service ProviderGolemApp {
-  rpc Compute (ComputeRequest) returns (ComputeReply) {}
-  rpc RunBenchmark (RunBenchmarkRequest) returns (RunBenchmarkReply) {}
+  rpc Shutdown (ShutdownRequest) returns (ShutdownReply) {}
 }
 
 
@@ -55,4 +52,11 @@ message RunBenchmarkRequest {
 
 message RunBenchmarkReply {
   float score = 1;
+}
+
+
+message ShutdownRequest {
+}
+
+message ShutdownReply {
 }

--- a/golem_task_api/proto/golem_task_api.proto
+++ b/golem_task_api/proto/golem_task_api.proto
@@ -2,13 +2,18 @@ syntax = "proto3";
 
 package golem_task_api;
 
-service GolemApp {
+service RequestorGolemApp {
   rpc CreateTask (CreateTaskRequest) returns (CreateTaskReply) {}
   rpc NextSubtask (NextSubtaskRequest) returns (NextSubtaskReply) {}
-  rpc Compute (ComputeRequest) returns (ComputeReply) {}
   rpc Verify (VerifyRequest) returns (VerifyReply) {}
   rpc RunBenchmark (RunBenchmarkRequest) returns (RunBenchmarkReply) {}
 }
+
+service ProviderGolemApp {
+  rpc Compute (ComputeRequest) returns (ComputeReply) {}
+  rpc RunBenchmark (RunBenchmarkRequest) returns (RunBenchmarkReply) {}
+}
+
 
 message CreateTaskRequest {
   string task_id = 1;

--- a/python/golem_task_api/__init__.py
+++ b/python/golem_task_api/__init__.py
@@ -1,7 +1,15 @@
-from .client import ProviderGolemAppClient, RequestorGolemAppClient
+from .client import (
+    ProviderAppCallbacks,
+    ProviderAppClient,
+    RequestorAppCallbacks,
+    RequestorAppClient,
+)
+
 from .server import (
-    ProviderGolemAppHandler,
-    RequestorGolemAppHandler,
-    ProviderGolemAppServer,
-    RequestorGolemAppServer,
+    entrypoint,
+)
+
+from .handlers import (
+    ProviderAppHandler,
+    RequestorAppHandler,
 )

--- a/python/golem_task_api/__init__.py
+++ b/python/golem_task_api/__init__.py
@@ -1,2 +1,7 @@
-from .client import GolemAppClient
-from .server import GolemAppHandler, GolemAppServer
+from .client import ProviderGolemAppClient, RequestorGolemAppClient
+from .server import (
+    ProviderGolemAppHandler,
+    RequestorGolemAppHandler,
+    ProviderGolemAppServer,
+    RequestorGolemAppServer,
+)

--- a/python/golem_task_api/handlers.py
+++ b/python/golem_task_api/handlers.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from typing import Tuple
+import abc
+
+
+class RequestorAppHandler:
+    @abc.abstractmethod
+    async def create_task(
+            self,
+            task_work_dir: Path,
+            task_params: dict,
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def next_subtask(
+            self,
+            task_work_dir: Path,
+    ) -> Tuple[str, dict]:
+        pass
+
+    @abc.abstractmethod
+    async def verify(
+            self,
+            task_work_dir: Path,
+            subtask_id: str,
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def run_benchmark(self, work_dir: Path) -> float:
+        pass
+
+
+class ProviderAppHandler:
+    @abc.abstractmethod
+    async def compute(
+            self,
+            task_work_dir: Path,
+            subtask_id: str,
+            subtask_params: dict,
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    async def run_benchmark(self, work_dir: Path) -> float:
+        pass

--- a/python/golem_task_api/messages.py
+++ b/python/golem_task_api/messages.py
@@ -9,5 +9,7 @@ from .proto.golem_task_api_pb2 import (
     VerifyReply,
     RunBenchmarkRequest,
     RunBenchmarkReply,
+    ShutdownRequest,
+    ShutdownReply,
 )
 

--- a/python/golem_task_api/proto/golem_task_api_grpc.py
+++ b/python/golem_task_api/proto/golem_task_api_grpc.py
@@ -9,7 +9,7 @@ import grpclib.client
 import golem_task_api.proto.golem_task_api_pb2
 
 
-class RequestorGolemAppBase(abc.ABC):
+class RequestorAppBase(abc.ABC):
 
     @abc.abstractmethod
     async def CreateTask(self, stream):
@@ -27,103 +27,75 @@ class RequestorGolemAppBase(abc.ABC):
     async def RunBenchmark(self, stream):
         pass
 
+    @abc.abstractmethod
+    async def Shutdown(self, stream):
+        pass
+
     def __mapping__(self):
         return {
-            '/golem_task_api.RequestorGolemApp/CreateTask': grpclib.const.Handler(
+            '/golem_task_api.RequestorApp/CreateTask': grpclib.const.Handler(
                 self.CreateTask,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.CreateTaskRequest,
                 golem_task_api.proto.golem_task_api_pb2.CreateTaskReply,
             ),
-            '/golem_task_api.RequestorGolemApp/NextSubtask': grpclib.const.Handler(
+            '/golem_task_api.RequestorApp/NextSubtask': grpclib.const.Handler(
                 self.NextSubtask,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.NextSubtaskRequest,
                 golem_task_api.proto.golem_task_api_pb2.NextSubtaskReply,
             ),
-            '/golem_task_api.RequestorGolemApp/Verify': grpclib.const.Handler(
+            '/golem_task_api.RequestorApp/Verify': grpclib.const.Handler(
                 self.Verify,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.VerifyRequest,
                 golem_task_api.proto.golem_task_api_pb2.VerifyReply,
             ),
-            '/golem_task_api.RequestorGolemApp/RunBenchmark': grpclib.const.Handler(
+            '/golem_task_api.RequestorApp/RunBenchmark': grpclib.const.Handler(
                 self.RunBenchmark,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
                 golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
             ),
+            '/golem_task_api.RequestorApp/Shutdown': grpclib.const.Handler(
+                self.Shutdown,
+                grpclib.const.Cardinality.UNARY_UNARY,
+                golem_task_api.proto.golem_task_api_pb2.ShutdownRequest,
+                golem_task_api.proto.golem_task_api_pb2.ShutdownReply,
+            ),
         }
 
 
-class RequestorGolemAppStub:
+class RequestorAppStub:
 
     def __init__(self, channel: grpclib.client.Channel) -> None:
         self.CreateTask = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.RequestorGolemApp/CreateTask',
+            '/golem_task_api.RequestorApp/CreateTask',
             golem_task_api.proto.golem_task_api_pb2.CreateTaskRequest,
             golem_task_api.proto.golem_task_api_pb2.CreateTaskReply,
         )
         self.NextSubtask = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.RequestorGolemApp/NextSubtask',
+            '/golem_task_api.RequestorApp/NextSubtask',
             golem_task_api.proto.golem_task_api_pb2.NextSubtaskRequest,
             golem_task_api.proto.golem_task_api_pb2.NextSubtaskReply,
         )
         self.Verify = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.RequestorGolemApp/Verify',
+            '/golem_task_api.RequestorApp/Verify',
             golem_task_api.proto.golem_task_api_pb2.VerifyRequest,
             golem_task_api.proto.golem_task_api_pb2.VerifyReply,
         )
         self.RunBenchmark = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.RequestorGolemApp/RunBenchmark',
+            '/golem_task_api.RequestorApp/RunBenchmark',
             golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
             golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
         )
-
-
-class ProviderGolemAppBase(abc.ABC):
-
-    @abc.abstractmethod
-    async def Compute(self, stream):
-        pass
-
-    @abc.abstractmethod
-    async def RunBenchmark(self, stream):
-        pass
-
-    def __mapping__(self):
-        return {
-            '/golem_task_api.ProviderGolemApp/Compute': grpclib.const.Handler(
-                self.Compute,
-                grpclib.const.Cardinality.UNARY_UNARY,
-                golem_task_api.proto.golem_task_api_pb2.ComputeRequest,
-                golem_task_api.proto.golem_task_api_pb2.ComputeReply,
-            ),
-            '/golem_task_api.ProviderGolemApp/RunBenchmark': grpclib.const.Handler(
-                self.RunBenchmark,
-                grpclib.const.Cardinality.UNARY_UNARY,
-                golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
-                golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
-            ),
-        }
-
-
-class ProviderGolemAppStub:
-
-    def __init__(self, channel: grpclib.client.Channel) -> None:
-        self.Compute = grpclib.client.UnaryUnaryMethod(
+        self.Shutdown = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.ProviderGolemApp/Compute',
-            golem_task_api.proto.golem_task_api_pb2.ComputeRequest,
-            golem_task_api.proto.golem_task_api_pb2.ComputeReply,
-        )
-        self.RunBenchmark = grpclib.client.UnaryUnaryMethod(
-            channel,
-            '/golem_task_api.ProviderGolemApp/RunBenchmark',
-            golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
-            golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
+            '/golem_task_api.RequestorApp/Shutdown',
+            golem_task_api.proto.golem_task_api_pb2.ShutdownRequest,
+            golem_task_api.proto.golem_task_api_pb2.ShutdownReply,
         )

--- a/python/golem_task_api/proto/golem_task_api_grpc.py
+++ b/python/golem_task_api/proto/golem_task_api_grpc.py
@@ -9,7 +9,7 @@ import grpclib.client
 import golem_task_api.proto.golem_task_api_pb2
 
 
-class GolemAppBase(abc.ABC):
+class RequestorGolemAppBase(abc.ABC):
 
     @abc.abstractmethod
     async def CreateTask(self, stream):
@@ -17,10 +17,6 @@ class GolemAppBase(abc.ABC):
 
     @abc.abstractmethod
     async def NextSubtask(self, stream):
-        pass
-
-    @abc.abstractmethod
-    async def Compute(self, stream):
         pass
 
     @abc.abstractmethod
@@ -33,31 +29,25 @@ class GolemAppBase(abc.ABC):
 
     def __mapping__(self):
         return {
-            '/golem_task_api.GolemApp/CreateTask': grpclib.const.Handler(
+            '/golem_task_api.RequestorGolemApp/CreateTask': grpclib.const.Handler(
                 self.CreateTask,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.CreateTaskRequest,
                 golem_task_api.proto.golem_task_api_pb2.CreateTaskReply,
             ),
-            '/golem_task_api.GolemApp/NextSubtask': grpclib.const.Handler(
+            '/golem_task_api.RequestorGolemApp/NextSubtask': grpclib.const.Handler(
                 self.NextSubtask,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.NextSubtaskRequest,
                 golem_task_api.proto.golem_task_api_pb2.NextSubtaskReply,
             ),
-            '/golem_task_api.GolemApp/Compute': grpclib.const.Handler(
-                self.Compute,
-                grpclib.const.Cardinality.UNARY_UNARY,
-                golem_task_api.proto.golem_task_api_pb2.ComputeRequest,
-                golem_task_api.proto.golem_task_api_pb2.ComputeReply,
-            ),
-            '/golem_task_api.GolemApp/Verify': grpclib.const.Handler(
+            '/golem_task_api.RequestorGolemApp/Verify': grpclib.const.Handler(
                 self.Verify,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.VerifyRequest,
                 golem_task_api.proto.golem_task_api_pb2.VerifyReply,
             ),
-            '/golem_task_api.GolemApp/RunBenchmark': grpclib.const.Handler(
+            '/golem_task_api.RequestorGolemApp/RunBenchmark': grpclib.const.Handler(
                 self.RunBenchmark,
                 grpclib.const.Cardinality.UNARY_UNARY,
                 golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
@@ -66,36 +56,74 @@ class GolemAppBase(abc.ABC):
         }
 
 
-class GolemAppStub:
+class RequestorGolemAppStub:
 
     def __init__(self, channel: grpclib.client.Channel) -> None:
         self.CreateTask = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.GolemApp/CreateTask',
+            '/golem_task_api.RequestorGolemApp/CreateTask',
             golem_task_api.proto.golem_task_api_pb2.CreateTaskRequest,
             golem_task_api.proto.golem_task_api_pb2.CreateTaskReply,
         )
         self.NextSubtask = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.GolemApp/NextSubtask',
+            '/golem_task_api.RequestorGolemApp/NextSubtask',
             golem_task_api.proto.golem_task_api_pb2.NextSubtaskRequest,
             golem_task_api.proto.golem_task_api_pb2.NextSubtaskReply,
         )
-        self.Compute = grpclib.client.UnaryUnaryMethod(
-            channel,
-            '/golem_task_api.GolemApp/Compute',
-            golem_task_api.proto.golem_task_api_pb2.ComputeRequest,
-            golem_task_api.proto.golem_task_api_pb2.ComputeReply,
-        )
         self.Verify = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.GolemApp/Verify',
+            '/golem_task_api.RequestorGolemApp/Verify',
             golem_task_api.proto.golem_task_api_pb2.VerifyRequest,
             golem_task_api.proto.golem_task_api_pb2.VerifyReply,
         )
         self.RunBenchmark = grpclib.client.UnaryUnaryMethod(
             channel,
-            '/golem_task_api.GolemApp/RunBenchmark',
+            '/golem_task_api.RequestorGolemApp/RunBenchmark',
+            golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
+            golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
+        )
+
+
+class ProviderGolemAppBase(abc.ABC):
+
+    @abc.abstractmethod
+    async def Compute(self, stream):
+        pass
+
+    @abc.abstractmethod
+    async def RunBenchmark(self, stream):
+        pass
+
+    def __mapping__(self):
+        return {
+            '/golem_task_api.ProviderGolemApp/Compute': grpclib.const.Handler(
+                self.Compute,
+                grpclib.const.Cardinality.UNARY_UNARY,
+                golem_task_api.proto.golem_task_api_pb2.ComputeRequest,
+                golem_task_api.proto.golem_task_api_pb2.ComputeReply,
+            ),
+            '/golem_task_api.ProviderGolemApp/RunBenchmark': grpclib.const.Handler(
+                self.RunBenchmark,
+                grpclib.const.Cardinality.UNARY_UNARY,
+                golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
+                golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
+            ),
+        }
+
+
+class ProviderGolemAppStub:
+
+    def __init__(self, channel: grpclib.client.Channel) -> None:
+        self.Compute = grpclib.client.UnaryUnaryMethod(
+            channel,
+            '/golem_task_api.ProviderGolemApp/Compute',
+            golem_task_api.proto.golem_task_api_pb2.ComputeRequest,
+            golem_task_api.proto.golem_task_api_pb2.ComputeReply,
+        )
+        self.RunBenchmark = grpclib.client.UnaryUnaryMethod(
+            channel,
+            '/golem_task_api.ProviderGolemApp/RunBenchmark',
             golem_task_api.proto.golem_task_api_pb2.RunBenchmarkRequest,
             golem_task_api.proto.golem_task_api_pb2.RunBenchmarkReply,
         )

--- a/python/golem_task_api/proto/golem_task_api_pb2.py
+++ b/python/golem_task_api/proto/golem_task_api_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='golem_task_api',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n)golem_task_api/proto/golem_task_api.proto\x12\x0egolem_task_api\">\n\x11\x43reateTaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x18\n\x10task_params_json\x18\x02 \x01(\t\"\x11\n\x0f\x43reateTaskReply\"%\n\x12NextSubtaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\"C\n\x10NextSubtaskReply\x12\x12\n\nsubtask_id\x18\x01 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x02 \x01(\t\"R\n\x0e\x43omputeRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x03 \x01(\t\"\x0e\n\x0c\x43omputeReply\"4\n\rVerifyRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\"\x1e\n\x0bVerifyReply\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x15\n\x13RunBenchmarkRequest\"\"\n\x11RunBenchmarkReply\x12\r\n\x05score\x18\x01 \x01(\x02\x32\xe0\x02\n\x11RequestorGolemApp\x12R\n\nCreateTask\x12!.golem_task_api.CreateTaskRequest\x1a\x1f.golem_task_api.CreateTaskReply\"\x00\x12U\n\x0bNextSubtask\x12\".golem_task_api.NextSubtaskRequest\x1a .golem_task_api.NextSubtaskReply\"\x00\x12\x46\n\x06Verify\x12\x1d.golem_task_api.VerifyRequest\x1a\x1b.golem_task_api.VerifyReply\"\x00\x12X\n\x0cRunBenchmark\x12#.golem_task_api.RunBenchmarkRequest\x1a!.golem_task_api.RunBenchmarkReply\"\x00\x32\xb7\x01\n\x10ProviderGolemApp\x12I\n\x07\x43ompute\x12\x1e.golem_task_api.ComputeRequest\x1a\x1c.golem_task_api.ComputeReply\"\x00\x12X\n\x0cRunBenchmark\x12#.golem_task_api.RunBenchmarkRequest\x1a!.golem_task_api.RunBenchmarkReply\"\x00\x62\x06proto3')
+  serialized_pb=_b('\n)golem_task_api/proto/golem_task_api.proto\x12\x0egolem_task_api\">\n\x11\x43reateTaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x18\n\x10task_params_json\x18\x02 \x01(\t\"\x11\n\x0f\x43reateTaskReply\"%\n\x12NextSubtaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\"C\n\x10NextSubtaskReply\x12\x12\n\nsubtask_id\x18\x01 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x02 \x01(\t\"R\n\x0e\x43omputeRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x03 \x01(\t\"\x0e\n\x0c\x43omputeReply\"4\n\rVerifyRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\"\x1e\n\x0bVerifyReply\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x15\n\x13RunBenchmarkRequest\"\"\n\x11RunBenchmarkReply\x12\r\n\x05score\x18\x01 \x01(\x02\"\x11\n\x0fShutdownRequest\"\x0f\n\rShutdownReply2\xa9\x03\n\x0cRequestorApp\x12R\n\nCreateTask\x12!.golem_task_api.CreateTaskRequest\x1a\x1f.golem_task_api.CreateTaskReply\"\x00\x12U\n\x0bNextSubtask\x12\".golem_task_api.NextSubtaskRequest\x1a .golem_task_api.NextSubtaskReply\"\x00\x12\x46\n\x06Verify\x12\x1d.golem_task_api.VerifyRequest\x1a\x1b.golem_task_api.VerifyReply\"\x00\x12X\n\x0cRunBenchmark\x12#.golem_task_api.RunBenchmarkRequest\x1a!.golem_task_api.RunBenchmarkReply\"\x00\x12L\n\x08Shutdown\x12\x1f.golem_task_api.ShutdownRequest\x1a\x1d.golem_task_api.ShutdownReply\"\x00\x62\x06proto3')
 )
 
 
@@ -349,6 +349,54 @@ _RUNBENCHMARKREPLY = _descriptor.Descriptor(
   serialized_end=495,
 )
 
+
+_SHUTDOWNREQUEST = _descriptor.Descriptor(
+  name='ShutdownRequest',
+  full_name='golem_task_api.ShutdownRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=497,
+  serialized_end=514,
+)
+
+
+_SHUTDOWNREPLY = _descriptor.Descriptor(
+  name='ShutdownReply',
+  full_name='golem_task_api.ShutdownReply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=516,
+  serialized_end=531,
+)
+
 DESCRIPTOR.message_types_by_name['CreateTaskRequest'] = _CREATETASKREQUEST
 DESCRIPTOR.message_types_by_name['CreateTaskReply'] = _CREATETASKREPLY
 DESCRIPTOR.message_types_by_name['NextSubtaskRequest'] = _NEXTSUBTASKREQUEST
@@ -359,6 +407,8 @@ DESCRIPTOR.message_types_by_name['VerifyRequest'] = _VERIFYREQUEST
 DESCRIPTOR.message_types_by_name['VerifyReply'] = _VERIFYREPLY
 DESCRIPTOR.message_types_by_name['RunBenchmarkRequest'] = _RUNBENCHMARKREQUEST
 DESCRIPTOR.message_types_by_name['RunBenchmarkReply'] = _RUNBENCHMARKREPLY
+DESCRIPTOR.message_types_by_name['ShutdownRequest'] = _SHUTDOWNREQUEST
+DESCRIPTOR.message_types_by_name['ShutdownReply'] = _SHUTDOWNREPLY
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 CreateTaskRequest = _reflection.GeneratedProtocolMessageType('CreateTaskRequest', (_message.Message,), dict(
@@ -431,20 +481,34 @@ RunBenchmarkReply = _reflection.GeneratedProtocolMessageType('RunBenchmarkReply'
   ))
 _sym_db.RegisterMessage(RunBenchmarkReply)
 
+ShutdownRequest = _reflection.GeneratedProtocolMessageType('ShutdownRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SHUTDOWNREQUEST,
+  __module__ = 'golem_task_api.proto.golem_task_api_pb2'
+  # @@protoc_insertion_point(class_scope:golem_task_api.ShutdownRequest)
+  ))
+_sym_db.RegisterMessage(ShutdownRequest)
+
+ShutdownReply = _reflection.GeneratedProtocolMessageType('ShutdownReply', (_message.Message,), dict(
+  DESCRIPTOR = _SHUTDOWNREPLY,
+  __module__ = 'golem_task_api.proto.golem_task_api_pb2'
+  # @@protoc_insertion_point(class_scope:golem_task_api.ShutdownReply)
+  ))
+_sym_db.RegisterMessage(ShutdownReply)
 
 
-_REQUESTORGOLEMAPP = _descriptor.ServiceDescriptor(
-  name='RequestorGolemApp',
-  full_name='golem_task_api.RequestorGolemApp',
+
+_REQUESTORAPP = _descriptor.ServiceDescriptor(
+  name='RequestorApp',
+  full_name='golem_task_api.RequestorApp',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=498,
-  serialized_end=850,
+  serialized_start=534,
+  serialized_end=959,
   methods=[
   _descriptor.MethodDescriptor(
     name='CreateTask',
-    full_name='golem_task_api.RequestorGolemApp.CreateTask',
+    full_name='golem_task_api.RequestorApp.CreateTask',
     index=0,
     containing_service=None,
     input_type=_CREATETASKREQUEST,
@@ -453,7 +517,7 @@ _REQUESTORGOLEMAPP = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='NextSubtask',
-    full_name='golem_task_api.RequestorGolemApp.NextSubtask',
+    full_name='golem_task_api.RequestorApp.NextSubtask',
     index=1,
     containing_service=None,
     input_type=_NEXTSUBTASKREQUEST,
@@ -462,7 +526,7 @@ _REQUESTORGOLEMAPP = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='Verify',
-    full_name='golem_task_api.RequestorGolemApp.Verify',
+    full_name='golem_task_api.RequestorApp.Verify',
     index=2,
     containing_service=None,
     input_type=_VERIFYREQUEST,
@@ -471,49 +535,25 @@ _REQUESTORGOLEMAPP = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='RunBenchmark',
-    full_name='golem_task_api.RequestorGolemApp.RunBenchmark',
+    full_name='golem_task_api.RequestorApp.RunBenchmark',
     index=3,
     containing_service=None,
     input_type=_RUNBENCHMARKREQUEST,
     output_type=_RUNBENCHMARKREPLY,
     serialized_options=None,
   ),
-])
-_sym_db.RegisterServiceDescriptor(_REQUESTORGOLEMAPP)
-
-DESCRIPTOR.services_by_name['RequestorGolemApp'] = _REQUESTORGOLEMAPP
-
-
-_PROVIDERGOLEMAPP = _descriptor.ServiceDescriptor(
-  name='ProviderGolemApp',
-  full_name='golem_task_api.ProviderGolemApp',
-  file=DESCRIPTOR,
-  index=1,
-  serialized_options=None,
-  serialized_start=853,
-  serialized_end=1036,
-  methods=[
   _descriptor.MethodDescriptor(
-    name='Compute',
-    full_name='golem_task_api.ProviderGolemApp.Compute',
-    index=0,
+    name='Shutdown',
+    full_name='golem_task_api.RequestorApp.Shutdown',
+    index=4,
     containing_service=None,
-    input_type=_COMPUTEREQUEST,
-    output_type=_COMPUTEREPLY,
-    serialized_options=None,
-  ),
-  _descriptor.MethodDescriptor(
-    name='RunBenchmark',
-    full_name='golem_task_api.ProviderGolemApp.RunBenchmark',
-    index=1,
-    containing_service=None,
-    input_type=_RUNBENCHMARKREQUEST,
-    output_type=_RUNBENCHMARKREPLY,
+    input_type=_SHUTDOWNREQUEST,
+    output_type=_SHUTDOWNREPLY,
     serialized_options=None,
   ),
 ])
-_sym_db.RegisterServiceDescriptor(_PROVIDERGOLEMAPP)
+_sym_db.RegisterServiceDescriptor(_REQUESTORAPP)
 
-DESCRIPTOR.services_by_name['ProviderGolemApp'] = _PROVIDERGOLEMAPP
+DESCRIPTOR.services_by_name['RequestorApp'] = _REQUESTORAPP
 
 # @@protoc_insertion_point(module_scope)

--- a/python/golem_task_api/proto/golem_task_api_pb2.py
+++ b/python/golem_task_api/proto/golem_task_api_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='golem_task_api',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n)golem_task_api/proto/golem_task_api.proto\x12\x0egolem_task_api\">\n\x11\x43reateTaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x18\n\x10task_params_json\x18\x02 \x01(\t\"\x11\n\x0f\x43reateTaskReply\"%\n\x12NextSubtaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\"C\n\x10NextSubtaskReply\x12\x12\n\nsubtask_id\x18\x01 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x02 \x01(\t\"R\n\x0e\x43omputeRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x03 \x01(\t\"\x0e\n\x0c\x43omputeReply\"4\n\rVerifyRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\"\x1e\n\x0bVerifyReply\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x15\n\x13RunBenchmarkRequest\"\"\n\x11RunBenchmarkReply\x12\r\n\x05score\x18\x01 \x01(\x02\x32\xa2\x03\n\x08GolemApp\x12R\n\nCreateTask\x12!.golem_task_api.CreateTaskRequest\x1a\x1f.golem_task_api.CreateTaskReply\"\x00\x12U\n\x0bNextSubtask\x12\".golem_task_api.NextSubtaskRequest\x1a .golem_task_api.NextSubtaskReply\"\x00\x12I\n\x07\x43ompute\x12\x1e.golem_task_api.ComputeRequest\x1a\x1c.golem_task_api.ComputeReply\"\x00\x12\x46\n\x06Verify\x12\x1d.golem_task_api.VerifyRequest\x1a\x1b.golem_task_api.VerifyReply\"\x00\x12X\n\x0cRunBenchmark\x12#.golem_task_api.RunBenchmarkRequest\x1a!.golem_task_api.RunBenchmarkReply\"\x00\x62\x06proto3')
+  serialized_pb=_b('\n)golem_task_api/proto/golem_task_api.proto\x12\x0egolem_task_api\">\n\x11\x43reateTaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x18\n\x10task_params_json\x18\x02 \x01(\t\"\x11\n\x0f\x43reateTaskReply\"%\n\x12NextSubtaskRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\"C\n\x10NextSubtaskReply\x12\x12\n\nsubtask_id\x18\x01 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x02 \x01(\t\"R\n\x0e\x43omputeRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\x12\x1b\n\x13subtask_params_json\x18\x03 \x01(\t\"\x0e\n\x0c\x43omputeReply\"4\n\rVerifyRequest\x12\x0f\n\x07task_id\x18\x01 \x01(\t\x12\x12\n\nsubtask_id\x18\x02 \x01(\t\"\x1e\n\x0bVerifyReply\x12\x0f\n\x07success\x18\x01 \x01(\x08\"\x15\n\x13RunBenchmarkRequest\"\"\n\x11RunBenchmarkReply\x12\r\n\x05score\x18\x01 \x01(\x02\x32\xe0\x02\n\x11RequestorGolemApp\x12R\n\nCreateTask\x12!.golem_task_api.CreateTaskRequest\x1a\x1f.golem_task_api.CreateTaskReply\"\x00\x12U\n\x0bNextSubtask\x12\".golem_task_api.NextSubtaskRequest\x1a .golem_task_api.NextSubtaskReply\"\x00\x12\x46\n\x06Verify\x12\x1d.golem_task_api.VerifyRequest\x1a\x1b.golem_task_api.VerifyReply\"\x00\x12X\n\x0cRunBenchmark\x12#.golem_task_api.RunBenchmarkRequest\x1a!.golem_task_api.RunBenchmarkReply\"\x00\x32\xb7\x01\n\x10ProviderGolemApp\x12I\n\x07\x43ompute\x12\x1e.golem_task_api.ComputeRequest\x1a\x1c.golem_task_api.ComputeReply\"\x00\x12X\n\x0cRunBenchmark\x12#.golem_task_api.RunBenchmarkRequest\x1a!.golem_task_api.RunBenchmarkReply\"\x00\x62\x06proto3')
 )
 
 
@@ -433,18 +433,18 @@ _sym_db.RegisterMessage(RunBenchmarkReply)
 
 
 
-_GOLEMAPP = _descriptor.ServiceDescriptor(
-  name='GolemApp',
-  full_name='golem_task_api.GolemApp',
+_REQUESTORGOLEMAPP = _descriptor.ServiceDescriptor(
+  name='RequestorGolemApp',
+  full_name='golem_task_api.RequestorGolemApp',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   serialized_start=498,
-  serialized_end=916,
+  serialized_end=850,
   methods=[
   _descriptor.MethodDescriptor(
     name='CreateTask',
-    full_name='golem_task_api.GolemApp.CreateTask',
+    full_name='golem_task_api.RequestorGolemApp.CreateTask',
     index=0,
     containing_service=None,
     input_type=_CREATETASKREQUEST,
@@ -453,7 +453,7 @@ _GOLEMAPP = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='NextSubtask',
-    full_name='golem_task_api.GolemApp.NextSubtask',
+    full_name='golem_task_api.RequestorGolemApp.NextSubtask',
     index=1,
     containing_service=None,
     input_type=_NEXTSUBTASKREQUEST,
@@ -461,18 +461,9 @@ _GOLEMAPP = _descriptor.ServiceDescriptor(
     serialized_options=None,
   ),
   _descriptor.MethodDescriptor(
-    name='Compute',
-    full_name='golem_task_api.GolemApp.Compute',
-    index=2,
-    containing_service=None,
-    input_type=_COMPUTEREQUEST,
-    output_type=_COMPUTEREPLY,
-    serialized_options=None,
-  ),
-  _descriptor.MethodDescriptor(
     name='Verify',
-    full_name='golem_task_api.GolemApp.Verify',
-    index=3,
+    full_name='golem_task_api.RequestorGolemApp.Verify',
+    index=2,
     containing_service=None,
     input_type=_VERIFYREQUEST,
     output_type=_VERIFYREPLY,
@@ -480,16 +471,49 @@ _GOLEMAPP = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='RunBenchmark',
-    full_name='golem_task_api.GolemApp.RunBenchmark',
-    index=4,
+    full_name='golem_task_api.RequestorGolemApp.RunBenchmark',
+    index=3,
     containing_service=None,
     input_type=_RUNBENCHMARKREQUEST,
     output_type=_RUNBENCHMARKREPLY,
     serialized_options=None,
   ),
 ])
-_sym_db.RegisterServiceDescriptor(_GOLEMAPP)
+_sym_db.RegisterServiceDescriptor(_REQUESTORGOLEMAPP)
 
-DESCRIPTOR.services_by_name['GolemApp'] = _GOLEMAPP
+DESCRIPTOR.services_by_name['RequestorGolemApp'] = _REQUESTORGOLEMAPP
+
+
+_PROVIDERGOLEMAPP = _descriptor.ServiceDescriptor(
+  name='ProviderGolemApp',
+  full_name='golem_task_api.ProviderGolemApp',
+  file=DESCRIPTOR,
+  index=1,
+  serialized_options=None,
+  serialized_start=853,
+  serialized_end=1036,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='Compute',
+    full_name='golem_task_api.ProviderGolemApp.Compute',
+    index=0,
+    containing_service=None,
+    input_type=_COMPUTEREQUEST,
+    output_type=_COMPUTEREPLY,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='RunBenchmark',
+    full_name='golem_task_api.ProviderGolemApp.RunBenchmark',
+    index=1,
+    containing_service=None,
+    input_type=_RUNBENCHMARKREQUEST,
+    output_type=_RUNBENCHMARKREPLY,
+    serialized_options=None,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_PROVIDERGOLEMAPP)
+
+DESCRIPTOR.services_by_name['ProviderGolemApp'] = _PROVIDERGOLEMAPP
 
 # @@protoc_insertion_point(module_scope)

--- a/python/golem_task_api/server.py
+++ b/python/golem_task_api/server.py
@@ -6,7 +6,10 @@ from typing import Tuple
 
 from grpclib.server import Server
 
-from golem_task_api.proto.golem_task_api_grpc import GolemAppBase
+from golem_task_api.proto.golem_task_api_grpc import (
+    RequestorGolemAppBase,
+    ProviderGolemAppBase,
+)
 from golem_task_api.messages import (
     CreateTaskRequest,
     CreateTaskReply,
@@ -21,7 +24,7 @@ from golem_task_api.messages import (
 )
 
 
-class GolemAppHandler:
+class RequestorGolemAppHandler:
     @abc.abstractmethod
     async def create_task(
             self,
@@ -36,14 +39,6 @@ class GolemAppHandler:
         pass
 
     @abc.abstractmethod
-    async def compute(
-            self,
-            task_work_dir: Path,
-            subtask_id: str,
-            subtask_params: dict) -> None:
-        pass
-
-    @abc.abstractmethod
     async def verify(
             self,
             task_work_dir: Path,
@@ -55,9 +50,26 @@ class GolemAppHandler:
         pass
 
 
-class GolemApp(GolemAppBase):
+class ProviderGolemAppHandler:
+    @abc.abstractmethod
+    async def compute(
+            self,
+            task_work_dir: Path,
+            subtask_id: str,
+            subtask_params: dict) -> None:
+        pass
 
-    def __init__(self, work_dir: Path, handler: GolemAppHandler) -> None:
+    @abc.abstractmethod
+    async def run_benchmark(self, work_dir: Path) -> float:
+        pass
+
+
+class RequestorGolemApp(RequestorGolemAppBase):
+
+    def __init__(
+            self,
+            work_dir: Path,
+            handler: RequestorGolemAppHandler) -> None:
         self._work_dir = work_dir
         self._handler = handler
 
@@ -81,16 +93,6 @@ class GolemApp(GolemAppBase):
         reply.subtask_params_json = json.dumps(subtask_params)
         await stream.send_message(reply)
 
-    async def Compute(self, stream):
-        request: ComputeRequest = await stream.recv_message()
-        task_id = request.task_id
-        subtask_id = request.subtask_id
-        task_work_dir = self._work_dir / task_id
-        subtask_params = json.loads(request.subtask_params_json)
-        await self._handler.compute(task_work_dir, subtask_id, subtask_params)
-        reply = ComputeReply()
-        await stream.send_message(reply)
-
     async def Verify(self, stream):
         request: VerifyRequest = await stream.recv_message()
         task_id = request.task_id
@@ -109,13 +111,61 @@ class GolemApp(GolemAppBase):
         await stream.send_message(reply)
 
 
-class GolemAppServer:
+class ProviderGolemApp(ProviderGolemAppBase):
+
+    def __init__(
+            self,
+            work_dir: Path,
+            handler: ProviderGolemAppHandler) -> None:
+        self._work_dir = work_dir
+        self._handler = handler
+
+    async def Compute(self, stream):
+        request: ComputeRequest = await stream.recv_message()
+        task_id = request.task_id
+        subtask_id = request.subtask_id
+        task_work_dir = self._work_dir / task_id
+        subtask_params = json.loads(request.subtask_params_json)
+        await self._handler.compute(task_work_dir, subtask_id, subtask_params)
+        reply = ComputeReply()
+        await stream.send_message(reply)
+
+    async def RunBenchmark(self, stream):
+        request: RunBenchmarkRequest = await stream.recv_message()
+        score = await self._handler.run_benchmark(self._work_dir)
+        reply = RunBenchmarkReply()
+        reply.score = score
+        await stream.send_message(reply)
+
+
+class RequestorGolemAppServer:
     def __init__(
             self,
             work_dir: Path,
             port: int,
-            golem_app_handler: GolemAppHandler) -> None:
-        golem_app = GolemApp(work_dir, golem_app_handler)
+            handler: RequestorGolemAppHandler) -> None:
+        golem_app = RequestorGolemApp(work_dir, handler)
+        loop = asyncio.get_event_loop()
+        self._server = Server(handlers=[golem_app], loop=loop)
+        self._port = port
+
+    async def start(self):
+        print(f'Starting server at port {self._port}')
+        await self._server.start('', self._port, ssl=None)
+
+    async def stop(self):
+        print("Stopping server...")
+        self._server.close()
+        await self._server.wait_closed()
+
+
+class ProviderGolemAppServer:
+    def __init__(
+            self,
+            work_dir: Path,
+            port: int,
+            handler: ProviderGolemAppHandler) -> None:
+        golem_app = ProviderGolemApp(work_dir, handler)
         loop = asyncio.get_event_loop()
         self._server = Server(handlers=[golem_app], loop=loop)
         self._port = port


### PR DESCRIPTION
So that requestor and provider sides can have independent Docker images.
This approach turned out to not be Docker specific.
Usage:
The application implements appropriate interfaces from `.handlers` and sets the `entrypoint` method as the entrypoint.
Golem uses classes from `.client` to communicate with the app. Those classes take `run_command` parameter which is supposed to e.g. invoke Docker with the given command. See corresponding blenderapp PR for more concrete usage.