### PR TITLE
Fix return value of ProviderAppClient.compute

### DIFF
--- a/python/golem_task_api/client.py
+++ b/python/golem_task_api/client.py
@@ -162,7 +162,7 @@ class ProviderAppClient:
         request.subtask_params_json = json.dumps(subtask_params)
         reply = await golem_app.Compute(request)
         await service.wait_until_shutdown_complete()
-        return reply.output_filepath
+        return Path(reply.output_filepath)
 
     @classmethod
     async def run_benchmark(


### PR DESCRIPTION
This method is supposed to return a `Path` while it returns a string.