### PR TITLE
Directories naming change

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The API is divided into two independent parts - requestor and provider.
 ## Requestor
 For requestor the app should implement a long running RPC service which implements the `RequestorApp` interface from the proto files. The app should assume it will have access to a single directory (let's call it `work_dir`). Each task will have its own separate working directory under the main `work_dir`. You can assume that for a given `task_id` the first call will always be `CreateTask` and the following directories will exist under `work_dir` and they will be empty:
 - `{task_id}`
-- `{task_id}/{constants.RESOURCES}`
-- `{task_id}/{constants.NETWORK_RESOURCES}`
-- `{task_id}/{constants.RESULTS}`
-- `{task_id}/{constants.NETWORK_RESULTS}`
+- `{task_id}/{constants.TASK_INPUTS_DIR}`
+- `{task_id}/{constants.SUBTASK_INPUTS_DIR}`
+- `{task_id}/{constants.TASK_OUTPUTS_DIR}`
+- `{task_id}/{constants.SUBTASK_OUTPUTS_DIR}`
 
 ### RPC methods
 - `CreateTask`
@@ -24,7 +24,7 @@ For requestor the app should implement a long running RPC service which implemen
   - should treat `{work_dir}/{task_id}` as the working directory for the given task
   - `task_params_json` is a JSON string containing task specific parameters
   - will only be called once with given `task_id`
-  - can assume `{task_id}/{constants.RESOURCES}` contains all the resources provided by task creator
+  - can assume `{task_id}/{constants.TASK_INPUTS_DIR}` contains all the resources provided by task creator
 - `NextSubtask`
   - takes one argument `task_id`
   - can assume `CreateTask` was called earlier with the same `task_id`
@@ -52,7 +52,7 @@ For requestor the app should implement a long running RPC service which implemen
   - takes no arguments
   - should gracefully terminate the service
 
-When the last subtask is successfully verified on the requestor's side, the `work_dir/task_id/constants.RESULTS` directory should contain all result files and nothing else.
+When the last subtask is successfully verified on the requestor's side, the `work_dir/task_id/constants.TASK_OUTPUTS_DIR` directory should contain all result files and nothing else.
 
 ## Provider
 Provider app should implement a short-lived RPC service which implements the `ProviderApp` interface from the proto files. Short-lived means that there will be only one request issued per service instance, i.e. the service should shutdown automatically after handling the first and only request.
@@ -62,8 +62,8 @@ Provider app should implement a short-lived RPC service which implements the `Pr
   - gets a single working directory `task_work_dir` to operate on
   - different subtasks of the same task will have the same `task_work_dir`
   - takes `task_id`, `subtask_id`, `subtask_params_json` as arguments
-  - can assume the `{task_work_dir}/{constants.NETWORK_RESOURCES}` directory exists
-  - can assume that under `{task_work_dir}/{constants.NETWORK_RESOURCES}` are the resources specified in the corresponding `NextSubtask` call
+  - can assume the `{task_work_dir}/{constants.SUBTASK_INPUTS_DIR}` directory exists
+  - can assume that under `{task_work_dir}/{constants.SUBTASK_INPUTS_DIR}` are the resources specified in the corresponding `NextSubtask` call
   - returns a filepath (relative to the `task_work_dir`) of the result file which will be sent back to the requestor with unchanged name
 - `Benchmark`
   - takes no arguments

--- a/golem_task_api/proto/constants.proto
+++ b/golem_task_api/proto/constants.proto
@@ -6,17 +6,17 @@ package golem_task_api;
 import "google/protobuf/descriptor.proto";
 
 extend google.protobuf.FileOptions {
-    string RESOURCES_DIR = 51000;
-    string NETWORK_RESOURCES_DIR = 51001;
-    string RESULTS_DIR = 51002;
-    string NETWORK_RESULTS_DIR = 51003;
+    string TASK_INPUTS_DIR = 51000;
+    string SUBTASK_INPUTS_DIR = 51001;
+    string TASK_OUTPUTS_DIR = 51002;
+    string SUBTASK_OUTPUTS_DIR = 51003;
 
     string WORK_DIR = 51100;
 }
 
-option (RESOURCES_DIR) = "resources";
-option (NETWORK_RESOURCES_DIR) = "network_resources";
-option (RESULTS_DIR) = "results";
-option (NETWORK_RESULTS_DIR) = "network_results";
+option (TASK_INPUTS_DIR) = "task_inputs";
+option (SUBTASK_INPUTS_DIR) = "subtask_inputs";
+option (TASK_OUTPUTS_DIR) = "task_outputs";
+option (SUBTASK_OUTPUTS_DIR) = "subtask_outputs";
 
 option (WORK_DIR) = "golem/work";

--- a/python/golem_task_api/constants.py
+++ b/python/golem_task_api/constants.py
@@ -1,8 +1,8 @@
 # This file is auto-generated from gen_constants.py
 
 
-RESOURCES_DIR = 'resources'
-NETWORK_RESOURCES_DIR = 'network_resources'
-RESULTS_DIR = 'results'
-NETWORK_RESULTS_DIR = 'network_results'
+TASK_INPUTS_DIR = 'task_inputs'
+SUBTASK_INPUTS_DIR = 'subtask_inputs'
+TASK_OUTPUTS_DIR = 'task_outputs'
+SUBTASK_OUTPUTS_DIR = 'subtask_outputs'
 WORK_DIR = 'golem/work'

--- a/python/golem_task_api/proto/constants_pb2.py
+++ b/python/golem_task_api/proto/constants_pb2.py
@@ -20,39 +20,39 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='golem_task_api/proto/constants.proto',
   package='golem_task_api',
   syntax='proto3',
-  serialized_options=_b('\302\363\030\tresources\312\363\030\021network_resources\322\363\030\007results\332\363\030\017network_results\342\371\030\ngolem/work'),
-  serialized_pb=_b('\n$golem_task_api/proto/constants.proto\x12\x0egolem_task_api\x1a google/protobuf/descriptor.proto:5\n\rRESOURCES_DIR\x12\x1c.google.protobuf.FileOptions\x18\xb8\x8e\x03 \x01(\t:=\n\x15NETWORK_RESOURCES_DIR\x12\x1c.google.protobuf.FileOptions\x18\xb9\x8e\x03 \x01(\t:3\n\x0bRESULTS_DIR\x12\x1c.google.protobuf.FileOptions\x18\xba\x8e\x03 \x01(\t:;\n\x13NETWORK_RESULTS_DIR\x12\x1c.google.protobuf.FileOptions\x18\xbb\x8e\x03 \x01(\t:0\n\x08WORK_DIR\x12\x1c.google.protobuf.FileOptions\x18\x9c\x8f\x03 \x01(\tBN\xc2\xf3\x18\tresources\xca\xf3\x18\x11network_resources\xd2\xf3\x18\x07results\xda\xf3\x18\x0fnetwork_results\xe2\xf9\x18\ngolem/workb\x06proto3')
+  serialized_options=_b('\302\363\030\013task_inputs\312\363\030\016subtask_inputs\322\363\030\014task_outputs\332\363\030\017subtask_outputs\342\371\030\ngolem/work'),
+  serialized_pb=_b('\n$golem_task_api/proto/constants.proto\x12\x0egolem_task_api\x1a google/protobuf/descriptor.proto:7\n\x0fTASK_INPUTS_DIR\x12\x1c.google.protobuf.FileOptions\x18\xb8\x8e\x03 \x01(\t::\n\x12SUBTASK_INPUTS_DIR\x12\x1c.google.protobuf.FileOptions\x18\xb9\x8e\x03 \x01(\t:8\n\x10TASK_OUTPUTS_DIR\x12\x1c.google.protobuf.FileOptions\x18\xba\x8e\x03 \x01(\t:;\n\x13SUBTASK_OUTPUTS_DIR\x12\x1c.google.protobuf.FileOptions\x18\xbb\x8e\x03 \x01(\t:0\n\x08WORK_DIR\x12\x1c.google.protobuf.FileOptions\x18\x9c\x8f\x03 \x01(\tBR\xc2\xf3\x18\x0btask_inputs\xca\xf3\x18\x0esubtask_inputs\xd2\xf3\x18\x0ctask_outputs\xda\xf3\x18\x0fsubtask_outputs\xe2\xf9\x18\ngolem/workb\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_descriptor__pb2.DESCRIPTOR,])
 
 
-RESOURCES_DIR_FIELD_NUMBER = 51000
-RESOURCES_DIR = _descriptor.FieldDescriptor(
-  name='RESOURCES_DIR', full_name='golem_task_api.RESOURCES_DIR', index=0,
+TASK_INPUTS_DIR_FIELD_NUMBER = 51000
+TASK_INPUTS_DIR = _descriptor.FieldDescriptor(
+  name='TASK_INPUTS_DIR', full_name='golem_task_api.TASK_INPUTS_DIR', index=0,
   number=51000, type=9, cpp_type=9, label=1,
   has_default_value=False, default_value=_b("").decode('utf-8'),
   message_type=None, enum_type=None, containing_type=None,
   is_extension=True, extension_scope=None,
   serialized_options=None, file=DESCRIPTOR)
-NETWORK_RESOURCES_DIR_FIELD_NUMBER = 51001
-NETWORK_RESOURCES_DIR = _descriptor.FieldDescriptor(
-  name='NETWORK_RESOURCES_DIR', full_name='golem_task_api.NETWORK_RESOURCES_DIR', index=1,
+SUBTASK_INPUTS_DIR_FIELD_NUMBER = 51001
+SUBTASK_INPUTS_DIR = _descriptor.FieldDescriptor(
+  name='SUBTASK_INPUTS_DIR', full_name='golem_task_api.SUBTASK_INPUTS_DIR', index=1,
   number=51001, type=9, cpp_type=9, label=1,
   has_default_value=False, default_value=_b("").decode('utf-8'),
   message_type=None, enum_type=None, containing_type=None,
   is_extension=True, extension_scope=None,
   serialized_options=None, file=DESCRIPTOR)
-RESULTS_DIR_FIELD_NUMBER = 51002
-RESULTS_DIR = _descriptor.FieldDescriptor(
-  name='RESULTS_DIR', full_name='golem_task_api.RESULTS_DIR', index=2,
+TASK_OUTPUTS_DIR_FIELD_NUMBER = 51002
+TASK_OUTPUTS_DIR = _descriptor.FieldDescriptor(
+  name='TASK_OUTPUTS_DIR', full_name='golem_task_api.TASK_OUTPUTS_DIR', index=2,
   number=51002, type=9, cpp_type=9, label=1,
   has_default_value=False, default_value=_b("").decode('utf-8'),
   message_type=None, enum_type=None, containing_type=None,
   is_extension=True, extension_scope=None,
   serialized_options=None, file=DESCRIPTOR)
-NETWORK_RESULTS_DIR_FIELD_NUMBER = 51003
-NETWORK_RESULTS_DIR = _descriptor.FieldDescriptor(
-  name='NETWORK_RESULTS_DIR', full_name='golem_task_api.NETWORK_RESULTS_DIR', index=3,
+SUBTASK_OUTPUTS_DIR_FIELD_NUMBER = 51003
+SUBTASK_OUTPUTS_DIR = _descriptor.FieldDescriptor(
+  name='SUBTASK_OUTPUTS_DIR', full_name='golem_task_api.SUBTASK_OUTPUTS_DIR', index=3,
   number=51003, type=9, cpp_type=9, label=1,
   has_default_value=False, default_value=_b("").decode('utf-8'),
   message_type=None, enum_type=None, containing_type=None,
@@ -67,17 +67,17 @@ WORK_DIR = _descriptor.FieldDescriptor(
   is_extension=True, extension_scope=None,
   serialized_options=None, file=DESCRIPTOR)
 
-DESCRIPTOR.extensions_by_name['RESOURCES_DIR'] = RESOURCES_DIR
-DESCRIPTOR.extensions_by_name['NETWORK_RESOURCES_DIR'] = NETWORK_RESOURCES_DIR
-DESCRIPTOR.extensions_by_name['RESULTS_DIR'] = RESULTS_DIR
-DESCRIPTOR.extensions_by_name['NETWORK_RESULTS_DIR'] = NETWORK_RESULTS_DIR
+DESCRIPTOR.extensions_by_name['TASK_INPUTS_DIR'] = TASK_INPUTS_DIR
+DESCRIPTOR.extensions_by_name['SUBTASK_INPUTS_DIR'] = SUBTASK_INPUTS_DIR
+DESCRIPTOR.extensions_by_name['TASK_OUTPUTS_DIR'] = TASK_OUTPUTS_DIR
+DESCRIPTOR.extensions_by_name['SUBTASK_OUTPUTS_DIR'] = SUBTASK_OUTPUTS_DIR
 DESCRIPTOR.extensions_by_name['WORK_DIR'] = WORK_DIR
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(RESOURCES_DIR)
-google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(NETWORK_RESOURCES_DIR)
-google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(RESULTS_DIR)
-google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(NETWORK_RESULTS_DIR)
+google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(TASK_INPUTS_DIR)
+google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(SUBTASK_INPUTS_DIR)
+google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(TASK_OUTPUTS_DIR)
+google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(SUBTASK_OUTPUTS_DIR)
 google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(WORK_DIR)
 
 DESCRIPTOR._options = None

--- a/python/golem_task_api/testutils/tasklifecycleutil.py
+++ b/python/golem_task_api/testutils/tasklifecycleutil.py
@@ -100,25 +100,25 @@ class TaskLifecycleUtil:
     def mkdir_requestor(self, task_id: str) -> None:
         self.req_task_work_dir = self.req_work_dir / task_id
         self.req_task_work_dir.mkdir()
-        self.req_task_resources_dir = \
-            self.req_task_work_dir / constants.RESOURCES_DIR
-        self.req_task_resources_dir.mkdir()
-        self.req_task_net_resources_dir = \
-            self.req_task_work_dir / constants.NETWORK_RESOURCES_DIR
-        self.req_task_net_resources_dir.mkdir()
-        self.req_task_results_dir = \
-            self.req_task_work_dir / constants.RESULTS_DIR
-        self.req_task_results_dir.mkdir()
-        self.req_task_net_results_dir = \
-            self.req_task_work_dir / constants.NETWORK_RESULTS_DIR
-        self.req_task_net_results_dir.mkdir()
+        self.req_task_inputs_dir = \
+            self.req_task_work_dir / constants.TASK_INPUTS_DIR
+        self.req_task_inputs_dir.mkdir()
+        self.req_subtask_inputs_dir = \
+            self.req_task_work_dir / constants.SUBTASK_INPUTS_DIR
+        self.req_subtask_inputs_dir.mkdir()
+        self.req_task_outputs_dir = \
+            self.req_task_work_dir / constants.TASK_OUTPUTS_DIR
+        self.req_task_outputs_dir.mkdir()
+        self.req_subtask_outputs_dir = \
+            self.req_task_work_dir / constants.SUBTASK_OUTPUTS_DIR
+        self.req_subtask_outputs_dir.mkdir()
 
     def mkdir_provider_task(self, task_id: str) -> None:
         self.prov_task_work_dir = self.prov_work_dir / task_id
         self.prov_task_work_dir.mkdir()
-        self.prov_task_net_resources_dir = \
-            self.prov_task_work_dir / constants.NETWORK_RESOURCES_DIR
-        self.prov_task_net_resources_dir.mkdir()
+        self.prov_subtask_inputs_dir = \
+            self.prov_task_work_dir / constants.SUBTASK_INPUTS_DIR
+        self.prov_subtask_inputs_dir.mkdir()
 
     def mkdir_provider_subtask(self, subtask_id: str) -> None:
         prov_subtask_work_dir = self.prov_task_work_dir / subtask_id
@@ -126,13 +126,13 @@ class TaskLifecycleUtil:
 
     def put_resources_to_requestor(self, resources: List[Path]) -> None:
         for resource in resources:
-            shutil.copy2(resource, self.req_task_resources_dir)
+            shutil.copy2(resource, self.req_task_inputs_dir)
 
     def copy_resources_from_requestor(self, resources: List[str]) -> None:
         for resource_id in resources:
-            network_resource = self.req_task_net_resources_dir / resource_id
+            network_resource = self.req_subtask_inputs_dir / resource_id
             assert network_resource.exists()
-            shutil.copy2(network_resource, self.prov_task_net_resources_dir)
+            shutil.copy2(network_resource, self.prov_subtask_inputs_dir)
 
     def copy_result_from_provider(
             self,
@@ -143,7 +143,7 @@ class TaskLifecycleUtil:
         assert result.exists()
         shutil.copy2(
             result,
-            self.req_task_net_results_dir / f'{result.name}',
+            self.req_subtask_outputs_dir / f'{result.name}',
         )
 
     async def create_task(


### PR DESCRIPTION
`resources` -> `task inputs`
`network resources` -> `subtask inputs`
`network results` -> `subtask outputs`
`results` -> `task outputs`