### PR TITLE
App lifecycle handler

### DIFF
--- a/python/golem_task_api/__init__.py
+++ b/python/golem_task_api/__init__.py
@@ -9,6 +9,7 @@ from .entrypoint import (
 )
 
 from .handlers import (
+    AppLifecycleHandler,
     ProviderAppHandler,
     RequestorAppHandler,
 )

--- a/python/golem_task_api/entrypoint.py
+++ b/python/golem_task_api/entrypoint.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from golem_task_api.handlers import (
+    AppLifecycleHandler,
     ProviderAppHandler,
     RequestorAppHandler,
 )
@@ -16,21 +17,25 @@ async def entrypoint(
         work_dir: Path,
         argv: List[str],
         requestor_handler: Optional[RequestorAppHandler] = None,
+        requestor_lifecycle_handler: Optional[AppLifecycleHandler] = None,
         provider_handler: Optional[ProviderAppHandler] = None,
+        provider_lifecycle_handler: Optional[AppLifecycleHandler] = None,
 ):
     cmd = argv[0]
     argv = argv[1:]
     if cmd == 'requestor':
         server = RequestorAppServer(
             work_dir,
-            int(argv[0]),
-            requestor_handler,
+            port=int(argv[0]),
+            handler=requestor_handler,
+            lifecycle=requestor_lifecycle_handler or AppLifecycleHandler(),
         )
     elif cmd == 'provider':
         server = ProviderAppServer(
             work_dir,
-            int(argv[0]),
-            provider_handler,
+            port=int(argv[0]),
+            handler=provider_handler,
+            lifecycle=provider_lifecycle_handler or AppLifecycleHandler(),
         )
     else:
         raise Exception(f'Unknown command: {cmd}')

--- a/python/golem_task_api/handlers.py
+++ b/python/golem_task_api/handlers.py
@@ -1,8 +1,36 @@
+import abc
+import asyncio
+
 from pathlib import Path
 from typing import List, Tuple, Optional
-import abc
 
 from golem_task_api.structs import Subtask
+
+
+class AppLifecycleHandler:
+
+    def __init__(self) -> None:
+        self.shutdown_future = asyncio.get_event_loop().create_future()
+
+    async def on_before_startup(self) -> None:
+        pass
+
+    async def on_after_startup(self) -> None:
+        pass
+
+    async def on_before_shutdown(self) -> None:
+        pass
+
+    async def on_after_shutdown(self) -> None:
+        pass
+
+    def request_shutdown(self) -> None:
+        # Do not call shutdown multiple times, this can happen in case of errors
+        if not self.shutdown_future.done():
+            print('Triggering shutdown', flush=True)
+            self.shutdown_future.set_result(None)
+        else:
+            print('Shutdown already triggered', flush=True)
 
 
 class RequestorAppHandler:

--- a/python/golem_task_api/testutils/inlinetaskapiservice.py
+++ b/python/golem_task_api/testutils/inlinetaskapiservice.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 from golem_task_api import (
     TaskApiService,
     entrypoint,
+    AppLifecycleHandler,
     ProviderAppHandler,
     RequestorAppHandler,
 )
@@ -16,14 +17,18 @@ class InlineTaskApiService(TaskApiService):
     def __init__(
             self,
             work_dir: Path,
-            provider_handler: Optional[ProviderAppHandler]=None,
-            requestor_handler: Optional[RequestorAppHandler]=None,
+            requestor_handler: Optional[RequestorAppHandler] = None,
+            requestor_lifecycle_handler: Optional[AppLifecycleHandler] = None,
+            provider_handler: Optional[ProviderAppHandler] = None,
+            provider_lifecycle_handler: Optional[AppLifecycleHandler] = None,
     ) -> None:
         # get_child_watcher enables event loops in child threads
         asyncio.get_child_watcher()
         self._work_dir = work_dir
-        self._provider_handler = provider_handler
         self._requestor_handler = requestor_handler
+        self._requestor_lifecycle_handler = requestor_lifecycle_handler
+        self._provider_handler = provider_handler
+        self._provider_lifecycle_handler = provider_lifecycle_handler
         self._thread = None
 
     def _spawn(self, command: str):
@@ -32,8 +37,8 @@ class InlineTaskApiService(TaskApiService):
         loop.run_until_complete(entrypoint(
             self._work_dir,
             command.split(' '),
-            provider_handler=self._provider_handler,
             requestor_handler=self._requestor_handler,
+            provider_handler=self._provider_handler,
         ))
 
     def running(self) -> bool:

--- a/python/golem_task_api/testutils/tasklifecycleutil.py
+++ b/python/golem_task_api/testutils/tasklifecycleutil.py
@@ -9,6 +9,7 @@ from golem_task_api import (
     constants,
     ProviderAppClient,
     RequestorAppClient,
+    AppLifecycleHandler,
     ProviderAppHandler,
     RequestorAppHandler,
 )
@@ -34,12 +35,14 @@ class TaskLifecycleUtil:
     def init_provider_with_handler(
             self,
             provider_handler: ProviderAppHandler,
+            lifecycle_handler: AppLifecycleHandler,
             task_id: str,
     ) -> None:
         def get_task_api_service(work_dir: Path):
             return InlineTaskApiService(
                 work_dir,
                 provider_handler=provider_handler,
+                provider_lifecycle_handler=lifecycle_handler,
             )
         self.init_provider(get_task_api_service, task_id)
 
@@ -66,12 +69,14 @@ class TaskLifecycleUtil:
     async def init_requestor_with_handler(
             self,
             requestor_handler: RequestorAppHandler,
+            lifecycle_handler: AppLifecycleHandler,
             port: int = 50005,
     ):
         def get_task_api_service(work_dir: Path):
             return InlineTaskApiService(
                 work_dir,
                 requestor_handler=requestor_handler,
+                requestor_lifecycle_handler=lifecycle_handler,
             )
         async with self.init_requestor(get_task_api_service, port):
             yield self.requestor_client

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.13.1',
+    version='0.14.0',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.14.0',
+    version='0.15.0',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.13.0',
+    version='0.13.1',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from golem_task_api import (
+    AppLifecycleHandler,
     ProviderAppHandler,
     RequestorAppHandler,
     structs,
@@ -19,6 +20,7 @@ class AsyncMock(mock.MagicMock):
 @pytest.mark.asyncio
 async def test_e2e_flow(tmpdir):
     task_lifecycle_util = TaskLifecycleUtil(Path(tmpdir))
+    app_lifecycle_handler = AsyncMock(spec_set=AppLifecycleHandler)
     requestor_handler = AsyncMock(spec_set=RequestorAppHandler)
     provider_handler = AsyncMock(spec_set=ProviderAppHandler)
 
@@ -28,7 +30,7 @@ async def test_e2e_flow(tmpdir):
     task_params = {'test_param': 'test_value'}
 
     async with task_lifecycle_util.init_requestor_with_handler(
-            requestor_handler):
+            requestor_handler, app_lifecycle_handler):
         await task_lifecycle_util.create_task(
             task_id,
             max_subtasks_count,
@@ -42,6 +44,7 @@ async def test_e2e_flow(tmpdir):
         )
         task_lifecycle_util.init_provider_with_handler(
             provider_handler,
+            app_lifecycle_handler,
             task_id,
         )
         requestor_handler.has_pending_subtasks.return_value = True


### PR DESCRIPTION
The main responsibility of the `AppLifecycleHandler` class is to enable custom code execution before/after `AppServer._server` startup/shutdown. This pins the potential points of execution of the following:
- app bootstrapping
- app clean up
- starting up and tearing down background jobs

The `AppLifecycleHandler` is currently a stub of a planned default implementation responsible for thread management (indirectly).

Additionally, `AppLifecycleHandler` objects:
- own the `shutdown_future`
- expose a `request_shutdown` method, resolving the aforementioned future