### PR TITLE
Hard shutdown for app clients

### DIFF
--- a/python/golem_task_api/testutils/inlinetaskapiservice.py
+++ b/python/golem_task_api/testutils/inlinetaskapiservice.py
@@ -16,8 +16,8 @@ class InlineTaskApiService(TaskApiService):
     def __init__(
             self,
             work_dir: Path,
-            provider_handler: Optional[ProviderAppHandler]=None,
-            requestor_handler: Optional[RequestorAppHandler]=None,
+            provider_handler: Optional[ProviderAppHandler] = None,
+            requestor_handler: Optional[RequestorAppHandler] = None,
     ) -> None:
         # get_child_watcher enables event loops in child threads
         asyncio.get_child_watcher()
@@ -48,6 +48,9 @@ class InlineTaskApiService(TaskApiService):
         self._thread.start()
         host = '127.0.0.1'
         return host, port
+
+    async def stop(self) -> None:
+        pass  # Python thread cannot be killed
 
     async def wait_until_shutdown_complete(self) -> None:
         if not self.running():


### PR DESCRIPTION
* Added abstract `stop()` method to `TaskApiService` and used it to implement hard shutdown for `ProviderAppClient` and `RequestorAppClient`.
* Added `started_ctx()` method to `TaskApiService` and used it in `create()` methods to properly clean up the service in case client creation goes wrong or gets cancelled.