### PR TITLE
Perform a server health check instead of waiting until sockets are open

### DIFF
--- a/python/golem_task_api/client.py
+++ b/python/golem_task_api/client.py
@@ -53,7 +53,7 @@ async def _wait_for_channel(
             response = await client.Check(request)
             if response.status == HealthCheckResponse.SERVING:
                 return channel
-        except ConnectionError:
+        except (StreamTerminatedError, ConnectionError):
             pass
         await asyncio.sleep(0.1)
 

--- a/python/golem_task_api/client.py
+++ b/python/golem_task_api/client.py
@@ -43,7 +43,7 @@ async def _wait_for_channel(
         timeout: float = CONNECTION_TIMEOUT
 ) -> Channel:
     request = HealthCheckRequest()
-    request.service = ''
+    request.service = ''  # empty service name for a server check
 
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -55,6 +55,7 @@ async def _wait_for_channel(
                 return channel
         except (StreamTerminatedError, ConnectionError):
             pass
+        channel.close()
         await asyncio.sleep(0.1)
 
     raise TimeoutError

--- a/python/golem_task_api/client.py
+++ b/python/golem_task_api/client.py
@@ -2,13 +2,11 @@ import abc
 import asyncio
 import json
 import time
-from enum import Enum
 from typing import ClassVar, List, Tuple
 from pathlib import Path
 
 from grpclib.client import Channel
 from grpclib.exceptions import StreamTerminatedError
-from grpclib.health.service import OVERALL
 from grpclib.health.v1.health_grpc import HealthStub
 from grpclib.health.v1.health_pb2 import HealthCheckRequest, HealthCheckResponse
 from grpclib.utils import Wrapper

--- a/python/golem_task_api/server.py
+++ b/python/golem_task_api/server.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from grpclib import const
 from grpclib import server
+from grpclib.health.service import Health
 
 from golem_task_api.proto.golem_task_api_grpc import (
     ProviderAppBase,
@@ -198,7 +199,7 @@ class AppServer:
             lifecycle: AppLifecycleHandler
     ) -> None:
         self._server = server.Server(
-            handlers=[golem_app],
+            handlers=[golem_app, Health()],
             loop=asyncio.get_event_loop(),
         )
         self._port = port

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.15.0',
+    version='0.16.0',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.16.0',
+    version='0.15.1',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',


### PR DESCRIPTION
- add a health service handler to the gRPC server
- check server health instead of waiting for open sockets