### PR TITLE
Do not try to stop the service when its not running anymore

### DIFF
--- a/python/golem_task_api/client.py
+++ b/python/golem_task_api/client.py
@@ -139,7 +139,8 @@ class AppClient(abc.ABC):
             # Catching StreamTerminatedError and ConnectionRefusedError
             # because server might have stopped between calling
             # self._service.running() and self._soft_shutdown()
-            await self._service.stop()
+            if self._service.runnning():
+                await self._service.stop()
 
     @abc.abstractmethod
     async def _soft_shutdown(self) -> None:


### PR DESCRIPTION
When testing the `scripts/task_api_tests/basic_integration.py` on release `0.15.1` i found the service was stopped multiple times raising an error.

Checking for a running service solved this error.