### PR TITLE
Properly handle multiple shutdown requests

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.19.0',
+    version='0.19.1',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',


### PR DESCRIPTION
It should issue multiple `soft_shutdown`s, since they will fail in an unexpected way.