### PR TITLE
SSL context - do not verify host names

### DIFF
--- a/python/golem_task_api/ssl.py
+++ b/python/golem_task_api/ssl.py
@@ -22,6 +22,7 @@ def create_client_ssl_context(
         directory / client_key_file_name,
         directory / client_cert_file_name,
         server_cert_directory / server_cert_file_name,
+        ssl.Purpose.SERVER_AUTH
     )
 
 
@@ -37,6 +38,7 @@ def create_server_ssl_context(
         directory / server_key_file_name,
         directory / server_cert_file_name,
         directory / client_cert_file_name,
+        ssl.Purpose.CLIENT_AUTH
     )
 
 
@@ -44,6 +46,7 @@ def create_ssl_context(
         key_path: Path,
         cert_path: Path,
         verify_cert_path: Path,
+        purpose: ssl.Purpose,
 ) -> Optional[ssl.SSLContext]:
     """ Create an SSL context with """
 
@@ -57,9 +60,10 @@ def create_ssl_context(
         return None
 
     try:
-        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context = ssl.create_default_context(purpose)
         context.load_cert_chain(str(cert_path), str(key_path))
         context.load_verify_locations(str(verify_cert_path))
+        context.check_hostname = False
         return context
     except Exception as exc:
         print(f"Error creating SSL context: {exc}")

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.24.2',
+    version='0.24.3',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',


### PR DESCRIPTION
Additionally, provide a way to specify SSL context purpose (not required)