### PR TITLE
Move AppDefinition from golem-core to task-api. 

### DIFF
--- a/python/golem_task_api/apputils/app_definition.py
+++ b/python/golem_task_api/apputils/app_definition.py
@@ -4,7 +4,7 @@ import json
 import shutil
 
 from pathlib import Path
-from typing import Dict, Any, Iterator, Type
+from typing import Dict, Any
 
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json, config
@@ -26,9 +26,10 @@ class AppDefinitionBase:
     description: str = ''
     author: str = ''
     license: str = ''
-    market_strategy: mm_fields.Str(
-        validate=validate.OneOf(["brass", "wasm"])
-    ) = 'brass'
+    market_strategy: str = mm_fields.Str(
+        validate=validate.OneOf(["brass", "wasm"]),
+        default='brass'
+    )
 
     @property
     def id(self) -> AppId:
@@ -53,7 +54,7 @@ def save_app_to_json_file(app_def: AppDefinitionBase, json_file: Path) -> None:
         json_file.write_text(app_def.to_json())
     except OSError:
         msg = f"Error writing app definition to file '{json_file}."
-        logger.exception(msg)
+        print(msg)
         raise ValueError(msg)
 
 
@@ -61,7 +62,8 @@ class BuildAppDefCommand(cmd.Command):
     description = 'build app definition for distribution in golem'
     user_options = [
         # The format is (long option, short option, description).
-        ('dist-path', 'd', 'Path to output build results, will be deleted before build'),
+        ('dist-path', 'd',
+            'Path to output build results, will be deleted before build'),
         ('config-path', 'c', 'Config file with task-api settings'),
     ]
 
@@ -107,6 +109,6 @@ class BuildAppDefCommand(cmd.Command):
             max_benchmark_score=self.config['max_benchmark_score'],
         )
         file = self.dist_path / f'{name.replace("/", "_")}_{version}_' \
-                f'{app_definition.id}.json'
+            f'{app_definition.id}.json'
         save_app_to_json_file(app_definition, file)
         print(f'Saved app_definition to "{file}"')

--- a/python/golem_task_api/apputils/app_definition.py
+++ b/python/golem_task_api/apputils/app_definition.py
@@ -1,6 +1,7 @@
 from distutils import cmd
 import hashlib
 import json
+import logging
 import shutil
 
 from pathlib import Path
@@ -11,6 +12,8 @@ from dataclasses_json import dataclass_json, config
 from marshmallow import fields as mm_fields, validate
 
 AppId = str
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass_json
@@ -54,7 +57,7 @@ def save_app_to_json_file(app_def: AppDefinitionBase, json_file: Path) -> None:
         json_file.write_text(app_def.to_json())
     except OSError:
         msg = f"Error writing app definition to file '{json_file}."
-        print(msg)
+        logger.error(msg)
         raise ValueError(msg)
 
 
@@ -111,4 +114,4 @@ class BuildAppDefCommand(cmd.Command):
         file = self.dist_path / f'{name.replace("/", "_")}_{version}_' \
             f'{app_definition.id}.json'
         save_app_to_json_file(app_definition, file)
-        print(f'Saved app_definition to "{file}"')
+        logger.info('Saved app_definition to "%r"', file)

--- a/python/golem_task_api/apputils/app_definition.py
+++ b/python/golem_task_api/apputils/app_definition.py
@@ -1,0 +1,112 @@
+from distutils import cmd
+import hashlib
+import json
+import shutil
+
+from pathlib import Path
+from typing import Dict, Any, Iterator, Type
+
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
+from marshmallow import fields as mm_fields, validate
+
+AppId = str
+
+
+@dataclass_json
+@dataclass
+class AppDefinitionBase:
+    name: str
+    requestor_env: str
+    requestor_prereq: Dict[str, Any] = field(metadata=config(
+        mm_field=mm_fields.Dict(keys=mm_fields.Str())
+    ))
+    max_benchmark_score: float
+    version: str = '0.0'
+    description: str = ''
+    author: str = ''
+    license: str = ''
+    market_strategy: mm_fields.Str(
+        validate=validate.OneOf(["brass", "wasm"])
+    ) = 'brass'
+
+    @property
+    def id(self) -> AppId:
+        return hashlib.blake2b(  # pylint: disable=no-member
+            self.to_json().encode('utf-8'),
+            digest_size=16
+        ).hexdigest()
+
+    @classmethod
+    def from_json(cls, json_str: str) -> 'AppDefinitionBase':
+        raise NotImplementedError  # A stub to silence the linters
+
+    def to_json(self) -> str:
+        raise NotImplementedError  # A stub to silence the linters
+
+
+def save_app_to_json_file(app_def: AppDefinitionBase, json_file: Path) -> None:
+    """ Save application definition to the given file in JSON format.
+        Create parent directories if they don't exist. """
+    try:
+        json_file.parent.mkdir(parents=True, exist_ok=True)
+        json_file.write_text(app_def.to_json())
+    except OSError:
+        msg = f"Error writing app definition to file '{json_file}."
+        logger.exception(msg)
+        raise ValueError(msg)
+
+
+class BuildAppDefCommand(cmd.Command):
+    description = 'build app definition for distribution in golem'
+    user_options = [
+        # The format is (long option, short option, description).
+        ('dist-path', 'd', 'Path to output build results, will be deleted before build'),
+        ('config-path', 'c', 'Config file with task-api settings'),
+    ]
+
+    def initialize_options(self):
+        """Set default values for options."""
+        # Each user option must be listed here with their default value.
+        self.dist_path = ''
+        self.config_path = ''
+
+    def finalize_options(self):
+        """Post-process options."""
+        if self.dist_path:
+            self.dist_path = Path(self.dist_path)
+        else:
+            self.dist_path = Path('dist/')
+        if self.config_path:
+            self.config_path = Path(self.config_path)
+        else:
+            self.config_path = Path('task-api-config.json')
+        self.config = json.loads(self.config_path.read_text())
+
+    def run(self):
+        """Run command."""
+        shutil.rmtree(self.dist_path, ignore_errors=True)
+        self.dist_path.mkdir()
+
+        dist = self.distribution
+        version = dist.get_version()
+        description = dist.get_description()
+        author = dist.get_maintainer()
+        license = dist.get_license()
+
+        name = self.config['name']
+        app_definition = AppDefinitionBase(
+            name=name,
+            author=author,
+            license=license,
+            version=version,
+            market_strategy=self.config['market_strategy'],
+            description=description,
+            requestor_env=self.config['requestor_env'],
+            requestor_prereq=self.config['requestor_prereq'],
+            max_benchmark_score=self.config['max_benchmark_score'],
+        )
+        file = self.dist_path / f'{name.replace("/", "_")}_{version}_' \
+                f'{app_definition.id}.json'
+        save_app_to_json_file(app_definition, file)
+        print(f'Saved app_definition to "{file}"')

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 
+
 setup(
     name='Golem-Task-Api',
     version='0.24.4',
@@ -19,6 +20,14 @@ setup(
     install_requires=[
         'async-generator==1.10',
         'dataclasses==0.6',
+        'dataclasses-json==0.3.0',
+        'grpclib==0.2.4',
+        'protobuf==3.7.1',
+    ],
+    setup_requires=[
+        'async-generator==1.10',
+        'dataclasses==0.6',
+        'dataclasses-json==0.3.0',
         'grpclib==0.2.4',
         'protobuf==3.7.1',
     ],


### PR DESCRIPTION
Added helper command to build app_def from setup.py.

- Moved AppDefinition class from golem-core to here
- Added `BuildAppDefinitionCommand` to be used in the app repositories
- Implementation in app done in https://github.com/golemfactory/blenderapp/pull/54