### PR TITLE
Release 0.24.5

### DIFF
--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -1,5 +1,6 @@
 flake8==3.7.9
 mock
 mypy==0.750
+peewee==3.11.2
 pytest==3.6.3
 pytest-asyncio==0.10.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.24.4',
+    version='0.25.0',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Golem-Task-Api',
-    version='0.25.0',
+    version='0.24.5',
     url='https://github.com/golemfactory/golem/task-api/python',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,6 +23,5 @@ setup(
         'dataclasses-json==0.3.0',
         'grpclib==0.2.4',
         'protobuf==3.7.1',
-        'peewee==3.11.2',
     ]
 )


### PR DESCRIPTION
While testing this branch i found out #67 is not compatible with golem-core, since it uses `peewee==2.10.2`, created #70

Updates the version to 0.24.5 for release of pending issues.